### PR TITLE
reject emails not forwarded from Gmail

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -37,6 +37,12 @@ func handler(req *smtpsrv.Request) error {
 		}
 	}
 
+	// reject emails not forwarded from Gmail
+	if !strings.Contains(req.From, `+caf_=pr-log=mail-hook.tsg.ne.jp@`) {
+		log.Println(`[handler] mailfrom is ` + req.From + `, so it's probably not forwarding from Gmail`)
+		return nil
+	}
+
 	msg, err := parsemail.Parse(req.Message)
 	if err != nil {
 		log.Println(`[handler] fail to read, maybe because of huge size`)

--- a/handler.go
+++ b/handler.go
@@ -19,14 +19,12 @@ func handler(req *smtpsrv.Request) error {
 
 	// validate the from data
 	if *flagStrictValidation {
-		spam := req.SPFResult != spf.Pass
-		if spam {
-			// trust mails from gmail.com
-			from := req.From
-			ip, _, _ := net.SplitHostPort(req.RemoteAddr)
-			spfres, _, _ := spf.CheckHost(net.ParseIP(ip), `gmail.com`, from)
-			spam = spfres != spf.Pass
-		}
+		// trust mails from gmail.com
+		from := req.From
+		ip, _, _ := net.SplitHostPort(req.RemoteAddr)
+		spfres, _, _ := spf.CheckHost(net.ParseIP(ip), `gmail.com`, from)
+		spam := spfres != spf.Pass
+
 		if spam {
 			log.Println(`[handler] spam detected`)
 			// should say "you are spammer" to spammer.
@@ -35,12 +33,6 @@ func handler(req *smtpsrv.Request) error {
 			log.Println(`[handler] not mailable`)
 			return nil
 		}
-	}
-
-	// reject emails not forwarded from Gmail
-	if !strings.Contains(req.From, `+caf_=pr-log=mail-hook.tsg.ne.jp@`) {
-		log.Println(`[handler] mailfrom is ` + req.From + `, so it's probably not forwarding from Gmail`)
-		return nil
 	}
 
 	msg, err := parsemail.Parse(req.Message)


### PR DESCRIPTION
#広報 にスパムメールが転送されないよう、Gmailからの転送のみ処理するよう変更したつもりです